### PR TITLE
Multiple bug fixes: jump height, screen boundary, stuck items, and monster death by block.

### DIFF
--- a/bricks.js
+++ b/bricks.js
@@ -70,6 +70,8 @@ class Brick { // type 0 = invis, 1 = brick, 2 = question, 3 = block
             this.bounce = false;
             this.velocity = - 80;
 
+            this.killEnemiesAbove();
+
             switch (this.prize) {
                 case 'Coins':
                     if (this.startTime === 0) this.startTime = Date.now();
@@ -106,6 +108,20 @@ class Brick { // type 0 = invis, 1 = brick, 2 = question, 3 = block
         if (this.y > this.BB.top) this.y = this.BB.top;
 
     };
+
+    killEnemiesAbove() {
+        const that = this;
+        this.game.entities.forEach(entity => {
+            if (entity.BB && entity.BB.bottom <= this.BB.top && entity.BB.right > this.BB.left && entity.BB.left < this.BB.right) {
+                // Check if the entity is an enemy and kill it
+                if (entity instanceof Goomba || entity instanceof Koopa || entity instanceof PirahnaPlant || entity instanceof KoopaParatroopaGreen || entity instanceof KoopaParatroopaRed) {
+                    entity.dead = true;
+                    that.game.addEntity(new Score(that.game, entity.x, entity.y, 100));
+                    ASSET_MANAGER.playAsset("./audio/stomp.mp3");
+                }
+            }
+        });
+    }
 
     drawMinimap(ctx, mmX, mmY) {
         ctx.fillStyle = this.type === 2 ? "Gold" : "Brown";

--- a/items.js
+++ b/items.js
@@ -122,7 +122,12 @@ class Mushroom {
                         that.y = entity.BB.top - PARAMS.BLOCKWIDTH;
                         that.velocity.y = 0;
                         that.updateBB();
-                    } else if (entity !== that && !(entity instanceof Flower)) {
+                    } else if (entity !== that && !(entity instanceof Flower || entity instanceof Goomba
+                                                    || entity instanceof KoopaParatroopaRed || entity instanceof KoopaParatroopaGreen
+                                                    || entity instanceof Koopa || entity instanceof KoopaShell
+                                                    || entity instanceof PirahnaPlant || entity instanceof HammerBro
+                                                    || entity instanceof Hammer || entity instanceof FireBar
+                                                    || entity instanceof FireBar_Fire)) {
                         that.velocity.x = -that.velocity.x;
                     }
                 };

--- a/mario.js
+++ b/mario.js
@@ -424,6 +424,13 @@ class Mario {
             // update position
             this.x += this.velocity.x * TICK * PARAMS.SCALE;
             this.y += this.velocity.y * TICK * PARAMS.SCALE;
+
+            // Apply left boundary constraint
+            if (this.x < this.game.camera.x) {
+                this.x = this.game.camera.x;
+                this.velocity.x = Math.max(0, this.velocity.x);
+            }
+
             this.updateLastBB();
             this.updateBB();
 

--- a/mario.js
+++ b/mario.js
@@ -127,7 +127,7 @@ class Mario {
         else {
             if (this.game.down) // big mario is crouching
                 this.BB = new BoundingBox(this.x, this.y + PARAMS.BLOCKWIDTH, PARAMS.BLOCKWIDTH, PARAMS.BLOCKWIDTH);
-            else 
+            else
                 this.BB = new BoundingBox(this.x, this.y, PARAMS.BLOCKWIDTH, PARAMS.BLOCKWIDTH * 2);
         }
     };
@@ -324,11 +324,11 @@ class Mario {
 
                     if (this.game.A) { // jump
                         if (Math.abs(this.velocity.x) < 16) {
-                            this.velocity.y = -240;
+                            this.velocity.y = -280;
                             this.fallAcc = STOP_FALL;
                         }
                         else if (Math.abs(this.velocity.x) < 40) {
-                            this.velocity.y = -240;
+                            this.velocity.y = -280;
                             this.fallAcc = WALK_FALL;
                         }
                         else {
@@ -526,7 +526,7 @@ class Mario {
                             that.x = entity.BB.left - PARAMS.BLOCKWIDTH;
                             if (that.velocity.x > 0) that.velocity.x = 0;
                             if (entity instanceof SideTube && that.game.right) {
-                                that.game.camera.loadLevel(levelOne, 162.5 * PARAMS.BLOCKWIDTH, 11 * PARAMS.BLOCKWIDTH) 
+                                that.game.camera.loadLevel(levelOne, 162.5 * PARAMS.BLOCKWIDTH, 11 * PARAMS.BLOCKWIDTH)
                             }
                         } else if (that.lastBB.left >= entity.BB.right) { // Collided with the right
                             that.x = entity.BB.right;


### PR DESCRIPTION
## Features
In this PR, I added a screen boundary so that Mario can no longer go offscreen. 
Items also no longer get stuck and glitch on monsters. 
Jump height was modified so that Mario can make a four block high jump without momentum like in the original game. 
Monsters can now be killed by jump-punching the block beneath them. 

> Did you fully complete the assigned features? Yes

- [x] Fully completed
- [ ] Partially completed

> What features did you Complete?
-Jumping Height modification
-Screen Boundary
-Stuck Items bug fix
-Monsters now die when Mario strikes a block that is under it

> How did you go about implementing your features? I first spent a lot of time to understand the codebase and how everything interacts. I then systematically chose bugs/features that I felt were needed and implemented them. 


## Bugs

> Did you introduce any bugs or potential ones?

- [ ] Yes
- [x] No

## Contributors to the Feature
Jayden Fausto
- *Indicate the name of participants in this PR*

## Final check

Have you filled out this document and gave the pull request a descriptive name (Up on top of this document and the GitHub PR title)? Answer *Yes* and that means you are good to go! Thank you for your contribution.

- [X ] Yes
- [ ] No
